### PR TITLE
fix(datepicker) class is passed in

### DIFF
--- a/src/ws-date-picker/ws-date-picker.js
+++ b/src/ws-date-picker/ws-date-picker.js
@@ -24,7 +24,8 @@ export class WSDatePicker extends Component {
     placeholder: PropTypes.string,
     iconOnly: PropTypes.bool,
     options: PropTypes.object,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    className: PropTypes.string
   };
 
   static format = 'd.m.Y';
@@ -112,23 +113,30 @@ export class WSDatePicker extends Component {
    * @returns {Object}
    */
   render() {
+    const {
+      className,
+      iconOnly,
+      placeholder,
+    } = this.props;
+
     return (
       <div
-        className={`ws-date-picker ${this.props.iconOnly ? 'icon-only' : 'with-input'}`}
+        className={`ws-date-picker ${iconOnly ? 'icon-only' : 'with-input'}`}
         ref={element => { this.element = element; }}
       >
-        {!this.props.iconOnly && [
+        {!iconOnly && [
           <input
+            className={className ? className : ''}
             defaultValue={this.state.value}
-            placeholder={this.props.placeholder}
+            placeholder={placeholder}
             ref={element => { this.input = element; }}
             key="input"
           />,
           <span className="icon icon-calendar icon16" key="icon" />
         ]}
-        {this.props.iconOnly &&
+        {iconOnly &&
           <span
-            className="icon icon-calendar icon16"
+            className={`icon icon-calendar icon16 ${className ? className : ''}`}
             ref={element => { this.input = element; }}
             onClick={event => this.flatpickr.open(event)}
             onKeyPress={event => {


### PR DESCRIPTION
the date picker now accepts the className attribute for passing in extra classes - in my use case, an error class

normal:
<img width="613" alt="screen shot 2018-06-25 at 16 27 12" src="https://user-images.githubusercontent.com/1480168/41856811-49b2db02-7896-11e8-9cc1-65ccd4cde0a2.png">


error:
<img width="624" alt="screen shot 2018-06-25 at 16 27 33" src="https://user-images.githubusercontent.com/1480168/41856816-4c74326e-7896-11e8-953a-5f58ad8bc199.png">


markup:
<img width="522" alt="screen shot 2018-06-25 at 16 30 55" src="https://user-images.githubusercontent.com/1480168/41856820-4f1b01a0-7896-11e8-8831-281f72fcd43b.png">
